### PR TITLE
Fixed issue with "NullPointerException" after building into .jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>4.3.9.RELEASE</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
This was caused by the resource lookup process, which would only work if the files were organized into directories.
When packaged into a jar, the "new File(path).listFiles()" would throw the NullPointerException would occur.

This addition has the disadvantage of requiring the "org.springframework.spring-core" dependency, in order to be able to use the PathMatchingResourcePatternResolver class.

Also, the "boolean recursively" parameter is not being used, so that should be fixed eventually, if it is an issue.

This will solve #1 .
